### PR TITLE
Heroku hack: git.properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,8 +65,19 @@ dependencies {
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
 }
 
+// Hack: Heroku removes the .git folder so gradle-git-properties fails, this task fakes the git.properties file
+task generateGitPropertiesForHeroku(type: WriteProperties) {
+    outputFile file("$buildDir/git.properties")
+    properties([
+        'git.branch': 'N/A',
+        'git.commit.id.abbrev': System.env.HEROKU_SLUG_COMMIT ?: 'N/A',
+        'git.commit.time': 'N/A'
+    ])
+}
+
 processResources {
     filesMatching('build.yml') { it.expand(project.properties) }
+    from(generateGitPropertiesForHeroku)
 }
 
 jar {
@@ -77,16 +88,20 @@ test {
     useJUnitPlatform()
 }
 
-gradle.taskGraph.whenReady { graph ->
-    if (graph.hasTask(stage)) {
-        generateGitProperties.enabled = false
-    }
-}
-
 task stage {
     dependsOn assemble
     doLast {
         file('Procfile').text = "web: java -Dserver.port=\$PORT -jar ${relativePath(bootJar.archiveFile)}"
+    }
+}
+
+// Hack, see: generateGitPropertiesForHeroku task
+gradle.taskGraph.whenReady { graph ->
+    if (graph.hasTask(stage)) {
+        generateGitProperties.enabled = false
+    }
+    else {
+        generateGitPropertiesForHeroku.enabled = false
     }
 }
 


### PR DESCRIPTION
Heroku removes the .git folder so gradle-git-properties fails, this change fakes the git.properties file